### PR TITLE
Fix destination parsing on some platforms and add support to stop traceroute

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,11 @@ try {
         });
 
     tracer.trace('github.com');
+
+    // and you can terminate traceroute by calling `kill` method
+    setTimeout(() => {
+        tracer.kill()
+    }, 5000)
 } catch (ex) {
     console.log(ex);
 }

--- a/src/process.ts
+++ b/src/process.ts
@@ -65,8 +65,9 @@ export abstract class Process extends events.EventEmitter {
 
     public kill(signal?: NodeJS.Signals | number) {
         if (this.process) {
-            this.process.kill(signal)
+            const result = this.process.kill(signal)
             this.removeAllListeners()
+            return result
         }
     }
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -3,29 +3,41 @@ import validator from 'validator';
 import Traceroute from '../src/index';
 
 describe('Traceroute', () => {
-  it('should verify pid, destination, hops and close code', (wait) => {
-    const tracer = new Traceroute();
+    it('should verify pid, destination, hops and close code', (wait) => {
+        const tracer = new Traceroute();
 
-    tracer
-        .on('pid', (pid) => {
-            expect(Number.isInteger(pid)).toBeTruthy();
-        })
-        .on('destination', (destination) => {
-            expect(validator.isIP(destination)).toBeTruthy();
-        })
-        .on('hop', (hopObj) => {
-            const { hop, ip, rtt1 } = hopObj;
+        tracer
+            .on('pid', (pid) => {
+                expect(Number.isInteger(pid)).toBeTruthy();
+            })
+            .on('destination', (destination) => {
+                expect(validator.isIP(destination)).toBeTruthy();
+            })
+            .on('hop', (hopObj) => {
+                const { hop, ip, rtt1 } = hopObj;
 
-            expect(Number.isInteger(hop)).toBeTruthy();
-            expect(validator.isIP(ip) || ip === '*').toBeTruthy();
-            expect(/^\d+\.\d+\sms$/.test(rtt1) || rtt1 === '*').toBeTruthy();
-        })
-        .on('close', (code) => {
-            expect(Number.isInteger(code)).toBeTruthy();
+                expect(Number.isInteger(hop)).toBeTruthy();
+                expect(validator.isIP(ip) || ip === '*').toBeTruthy();
+                expect(/^\d+\.\d+\sms$/.test(rtt1) || rtt1 === '*').toBeTruthy();
+            })
+            .on('close', (code) => {
+                expect(Number.isInteger(code)).toBeTruthy();
 
-            wait();
-        });
+                wait();
+            });
 
-    tracer.trace('github.com');
-  }, 60000);
+        tracer.trace('github.com');
+    }, 60000);
+
+    it('should exit trace by calling kill method', (done) => {
+        const tracer = new Traceroute();
+
+        tracer.trace('github.com');
+
+        setTimeout(() => {
+            tracer.kill()
+            expect(tracer.process?.killed).toBeTruthy()
+            done()
+        }, 5000)
+    }, 10000);
 });

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -35,8 +35,9 @@ describe('Traceroute', () => {
         tracer.trace('github.com');
 
         setTimeout(() => {
-            tracer.kill()
+            const killResult = tracer.kill()
             expect(tracer.process?.killed).toBeTruthy()
+            expect(killResult).toBeTruthy()
             done()
         }, 5000)
     }, 10000);


### PR DESCRIPTION
fix #7, #14
On my mac with traceroute Version 1.4a12+Darwin, traceroute output destination
```
traceroute to example.com (x.x.x.x), 64 hops max, 40 byte packets
```
as stderr, so we need to parse stderr also.

And support #13 
add `kill` method to stop traceroute. Would be useful if in some case.